### PR TITLE
feat: add basic i18n support

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "express": "^5.1.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.15.0",
+    "@ngx-translate/core": "^15.0.0",
+    "@ngx-translate/http-loader": "^8.0.0"
   },
   "devDependencies": {
     "@angular/build": "^20.1.1",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,5 +1,8 @@
-import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
+import { ApplicationConfig, importProvidersFrom, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { I18nModule } from './core/i18n/i18n.module';
+import { LOCALE_ID_PROVIDER } from './core/i18n/i18n.service';
 
 import { routes } from './app.routes';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
@@ -8,6 +11,10 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideRouter(routes), provideClientHydration(withEventReplay())
+    provideRouter(routes),
+    provideClientHydration(withEventReplay()),
+    importProvidersFrom(I18nModule),
+    provideHttpClient(),
+    LOCALE_ID_PROVIDER
   ]
 };

--- a/src/app/core/i18n/i18n.module.ts
+++ b/src/app/core/i18n/i18n.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+
+export function HttpLoaderFactory(http: HttpClient): TranslateHttpLoader {
+  return new TranslateHttpLoader(http, 'assets/i18n/', '.json');
+}
+
+@NgModule({
+  imports: [
+    TranslateModule.forRoot({
+      loader: {
+        provide: TranslateLoader,
+        useFactory: HttpLoaderFactory,
+        deps: [HttpClient]
+      }
+    })
+  ],
+  exports: [TranslateModule]
+})
+export class I18nModule {}

--- a/src/app/core/i18n/i18n.service.ts
+++ b/src/app/core/i18n/i18n.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, LOCALE_ID, Signal, computed, inject, signal } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+
+@Injectable({ providedIn: 'root' })
+export class I18nService {
+  private currentLang = signal('pt-BR');
+  constructor(private translate: TranslateService) {
+    translate.addLangs(['en', 'pt-BR']);
+    translate.setDefaultLang('pt-BR');
+    this.use(this.currentLang());
+  }
+
+  use(lang: string): void {
+    this.currentLang.set(lang);
+    this.translate.use(lang);
+  }
+
+  lang(): string {
+    return this.currentLang();
+  }
+
+  t(key: string, params?: Record<string, unknown>): string {
+    return this.translate.instant(key, params);
+  }
+}
+
+export const LOCALE_ID_PROVIDER = {
+  provide: LOCALE_ID,
+  deps: [I18nService],
+  useFactory: (i18n: I18nService) => i18n.lang()
+};

--- a/src/app/layout/footer/footer.html
+++ b/src/app/layout/footer/footer.html
@@ -1,11 +1,11 @@
 <footer class="footer">
   <div class="container">
     <div class="footer-content">
-      <p>&copy; 2025 Meu Portfólio. Todos os direitos reservados.</p>
+      <p>{{ 'LAYOUT.FOOTER.COPYRIGHT' | translate }}</p>
       <div class="social-links">
-        <a href="#" class="social-link">LinkedIn</a>
-        <a href="#" class="social-link">GitHub</a>
-        <a href="#" class="social-link">Email</a>
+        <a href="#" class="social-link">{{ 'LAYOUT.FOOTER.LINKEDIN' | translate }}</a>
+        <a href="#" class="social-link">{{ 'LAYOUT.FOOTER.GITHUB' | translate }}</a>
+        <a href="#" class="social-link">{{ 'LAYOUT.FOOTER.EMAIL' | translate }}</a>
       </div>
     </div>
   </div>

--- a/src/app/layout/footer/footer.ts
+++ b/src/app/layout/footer/footer.ts
@@ -1,8 +1,9 @@
 import { Component } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-footer',
-  imports: [],
+  imports: [TranslateModule],
   templateUrl: './footer.html',
   styleUrl: './footer.scss'
 })

--- a/src/app/layout/header/header.html
+++ b/src/app/layout/header/header.html
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="header-content">
       <div class="logo">
-        <h1>Meu Portfólio</h1>
+        <h1>{{ 'LAYOUT.HEADER.TITLE' | translate }}</h1>
       </div>
       <app-navigation></app-navigation>
     </div>

--- a/src/app/layout/header/header.ts
+++ b/src/app/layout/header/header.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
 import { NavigationComponent } from '../navigation/navigation';
 
 @Component({
   selector: 'app-header',
-  imports: [NavigationComponent],
+  imports: [NavigationComponent, TranslateModule],
   templateUrl: './header.html',
   styleUrl: './header.scss'
 })

--- a/src/app/layout/navigation/navigation.html
+++ b/src/app/layout/navigation/navigation.html
@@ -7,7 +7,7 @@
           routerLinkActive="active"
           [routerLinkActiveOptions]="{exact: item.path === '/'}"
           class="nav-link">
-          {{ item.label }}
+          {{ item.label | translate }}
         </a>
       </li>
     }

--- a/src/app/layout/navigation/navigation.ts
+++ b/src/app/layout/navigation/navigation.ts
@@ -1,18 +1,19 @@
 import { Component } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-navigation',
-  imports: [RouterLink, RouterLinkActive],
+  imports: [RouterLink, RouterLinkActive, TranslateModule],
   templateUrl: './navigation.html',
   styleUrl: './navigation.scss'
 })
 export class NavigationComponent {
   navigationItems = [
-    { path: '/', label: 'Home' },
-    { path: '/about', label: 'Sobre' },
-    { path: '/projects', label: 'Projetos' },
-    { path: '/resume', label: 'Currículo' },
-    { path: '/contact', label: 'Contato' }
+    { path: '/', label: 'LAYOUT.NAV.HOME' },
+    { path: '/about', label: 'LAYOUT.NAV.ABOUT' },
+    { path: '/projects', label: 'LAYOUT.NAV.PROJECTS' },
+    { path: '/resume', label: 'LAYOUT.NAV.RESUME' },
+    { path: '/contact', label: 'LAYOUT.NAV.CONTACT' }
   ];
 }

--- a/src/app/pages/home/home.html
+++ b/src/app/pages/home/home.html
@@ -3,20 +3,19 @@
   <section class="hero">
     <div class="container">
       <div class="hero-content">
-        <h1 class="hero-title">Olá, eu sou <span class="highlight">Jean Lucca</span></h1>
-        <h2 class="hero-subtitle">Tech Lead & Arquiteto de Software & dev FullStack</h2>
+        <h1 class="hero-title" [innerHTML]="'HOME.HERO.TITLE' | translate"></h1>
+        <h2 class="hero-subtitle">{{ 'HOME.HERO.SUBTITLE' | translate }}</h2>
         <p class="hero-description">
-          Cientista de Dados, especialista em Python e líder técnico.
-          Apaixonado por criar soluções inovadoras e escaláveis.
+          {{ 'HOME.HERO.DESCRIPTION' | translate }}
         </p>
         <div class="hero-actions">
-          <a routerLink="/projects" class="btn btn-primary">Ver Projetos</a>
-          <a routerLink="/contact" class="btn btn-secondary">Entre em Contato</a>
+          <a routerLink="/projects" class="btn btn-primary">{{ 'HOME.HERO.BTN_PROJECTS' | translate }}</a>
+          <a routerLink="/contact" class="btn btn-secondary">{{ 'HOME.HERO.BTN_CONTACT' | translate }}</a>
         </div>
       </div>
       <div class="hero-image">
         <div class="profile-placeholder">
-          <span>Foto do Perfil</span>
+          <span>{{ 'HOME.HERO.PROFILE_PLACEHOLDER' | translate }}</span>
         </div>
       </div>
     </div>
@@ -25,10 +24,10 @@
   <!-- Skills Section -->
   <section class="skills">
     <div class="container">
-      <h2 class="section-title">Principais Tecnologias</h2>
+      <h2 class="section-title">{{ 'HOME.SKILLS.TITLE' | translate }}</h2>
       <div class="skills-grid">
         <div class="skill-card">
-          <h3>Frontend</h3>
+          <h3>{{ 'HOME.SKILLS.FRONTEND' | translate }}</h3>
           <ul>
             <li>Angular 17+</li>
             <li>TypeScript</li>
@@ -36,7 +35,7 @@
           </ul>
         </div>
         <div class="skill-card">
-          <h3>Backend</h3>
+          <h3>{{ 'HOME.SKILLS.BACKEND' | translate }}</h3>
           <ul>
             <li>Node.js</li>
             <li>Express.js</li>
@@ -48,7 +47,7 @@
           </ul>
         </div>
         <div class="skill-card">
-          <h3>Mobile</h3>
+          <h3>{{ 'HOME.SKILLS.MOBILE' | translate }}</h3>
           <ul>
             <li>Flutter</li>
             <li>Dart</li>
@@ -57,7 +56,7 @@
           </ul>
         </div>
         <div class="skill-card">
-          <h3>DevOps</h3>
+          <h3>{{ 'HOME.SKILLS.DEVOPS' | translate }}</h3>
           <ul>
             <li>Docker</li>
             <li>AWS</li>
@@ -66,7 +65,7 @@
           </ul>
         </div>
         <div class="skill-card">
-          <h3>Machine Learning</h3>
+          <h3>{{ 'HOME.SKILLS.ML' | translate }}</h3>
           <ul>
             <li>Python</li>
             <li>Pandas</li>
@@ -83,15 +82,15 @@
   <!-- Featured Projects -->
   <section class="featured-projects">
     <div class="container">
-      <h2 class="section-title">Projetos em Destaque</h2>
+      <h2 class="section-title">{{ 'HOME.FEATURED.TITLE' | translate }}</h2>
       <div class="projects-grid">
         <div class="project-card">
           <div class="project-image">
             <span>Imagem do Projeto 1</span>
           </div>
           <div class="project-content">
-            <h3>E-commerce Platform</h3>
-            <p>Plataforma completa de e-commerce com Angular e Node.js</p>
+            <h3>{{ 'HOME.FEATURED.PROJECT1.TITLE' | translate }}</h3>
+            <p>{{ 'HOME.FEATURED.PROJECT1.DESC' | translate }}</p>
             <div class="project-tech">
               <span class="tech-tag">Angular</span>
               <span class="tech-tag">Node.js</span>
@@ -104,8 +103,8 @@
             <span>Imagem do Projeto 2</span>
           </div>
           <div class="project-content">
-            <h3>Task Management App</h3>
-            <p>Aplicativo de gerenciamento de tarefas com real-time</p>
+            <h3>{{ 'HOME.FEATURED.PROJECT2.TITLE' | translate }}</h3>
+            <p>{{ 'HOME.FEATURED.PROJECT2.DESC' | translate }}</p>
             <div class="project-tech">
               <span class="tech-tag">Angular</span>
               <span class="tech-tag">Socket.io</span>
@@ -118,8 +117,8 @@
             <span>Imagem do Projeto 3</span>
           </div>
           <div class="project-content">
-            <h3>Analytics Dashboard</h3>
-            <p>Dashboard de analytics com visualizações interativas</p>
+            <h3>{{ 'HOME.FEATURED.PROJECT3.TITLE' | translate }}</h3>
+            <p>{{ 'HOME.FEATURED.PROJECT3.DESC' | translate }}</p>
             <div class="project-tech">
               <span class="tech-tag">Angular</span>
               <span class="tech-tag">D3.js</span>
@@ -129,7 +128,7 @@
         </div>
       </div>
       <div class="projects-cta">
-        <a routerLink="/projects" class="btn btn-outline">Ver Todos os Projetos</a>
+        <a routerLink="/projects" class="btn btn-outline">{{ 'HOME.FEATURED.BTN_ALL' | translate }}</a>
       </div>
     </div>
   </section>
@@ -138,9 +137,9 @@
   <section class="cta">
     <div class="container">
       <div class="cta-content">
-        <h2>Vamos trabalhar juntos?</h2>
-        <p>Estou sempre aberto a novos desafios e oportunidades interessantes.</p>
-        <a routerLink="/contact" class="btn btn-primary">Entre em Contato</a>
+        <h2>{{ 'HOME.CTA.TITLE' | translate }}</h2>
+        <p>{{ 'HOME.CTA.DESC' | translate }}</p>
+        <a routerLink="/contact" class="btn btn-primary">{{ 'HOME.CTA.BTN_CONTACT' | translate }}</a>
       </div>
     </div>
   </section>

--- a/src/app/pages/home/home.ts
+++ b/src/app/pages/home/home.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-home',
-  imports: [RouterLink],
+  imports: [RouterLink, TranslateModule],
   templateUrl: './home.html',
   styleUrl: './home.scss'
 })

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1,0 +1,57 @@
+{
+  "LAYOUT": {
+    "HEADER": { "TITLE": "My Portfolio" },
+    "NAV": {
+      "HOME": "Home",
+      "ABOUT": "About",
+      "PROJECTS": "Projects",
+      "RESUME": "Resume",
+      "CONTACT": "Contact"
+    },
+    "FOOTER": {
+      "COPYRIGHT": "© 2025 My Portfolio. All rights reserved.",
+      "LINKEDIN": "LinkedIn",
+      "GITHUB": "GitHub",
+      "EMAIL": "Email"
+    }
+  },
+  "HOME": {
+    "HERO": {
+      "TITLE": "Hello, I'm <span class='highlight'>Jean Lucca</span>",
+      "SUBTITLE": "Tech Lead & Software Architect & FullStack dev",
+      "DESCRIPTION": "Data Scientist, Python specialist and tech leader. Passionate about creating innovative and scalable solutions.",
+      "BTN_PROJECTS": "View Projects",
+      "BTN_CONTACT": "Contact Me",
+      "PROFILE_PLACEHOLDER": "Profile Photo"
+    },
+    "SKILLS": {
+      "TITLE": "Main Technologies",
+      "FRONTEND": "Frontend",
+      "BACKEND": "Backend",
+      "MOBILE": "Mobile",
+      "DEVOPS": "DevOps",
+      "ML": "Machine Learning"
+    },
+    "FEATURED": {
+      "TITLE": "Featured Projects",
+      "PROJECT1": {
+        "TITLE": "E-commerce Platform",
+        "DESC": "Complete e-commerce platform with Angular and Node.js"
+      },
+      "PROJECT2": {
+        "TITLE": "Task Management App",
+        "DESC": "Task management app with real-time features"
+      },
+      "PROJECT3": {
+        "TITLE": "Analytics Dashboard",
+        "DESC": "Analytics dashboard with interactive visualizations"
+      },
+      "BTN_ALL": "View All Projects"
+    },
+    "CTA": {
+      "TITLE": "Shall we work together?",
+      "DESC": "I'm always open to new challenges and interesting opportunities.",
+      "BTN_CONTACT": "Contact Me"
+    }
+  }
+}

--- a/src/assets/i18n/pt-BR.json
+++ b/src/assets/i18n/pt-BR.json
@@ -1,0 +1,57 @@
+{
+  "LAYOUT": {
+    "HEADER": { "TITLE": "Meu Portfólio" },
+    "NAV": {
+      "HOME": "Home",
+      "ABOUT": "Sobre",
+      "PROJECTS": "Projetos",
+      "RESUME": "Currículo",
+      "CONTACT": "Contato"
+    },
+    "FOOTER": {
+      "COPYRIGHT": "© 2025 Meu Portfólio. Todos os direitos reservados.",
+      "LINKEDIN": "LinkedIn",
+      "GITHUB": "GitHub",
+      "EMAIL": "Email"
+    }
+  },
+  "HOME": {
+    "HERO": {
+      "TITLE": "Olá, eu sou <span class='highlight'>Jean Lucca</span>",
+      "SUBTITLE": "Tech Lead & Arquiteto de Software & dev FullStack",
+      "DESCRIPTION": "Cientista de Dados, especialista em Python e líder técnico. Apaixonado por criar soluções inovadoras e escaláveis.",
+      "BTN_PROJECTS": "Ver Projetos",
+      "BTN_CONTACT": "Entre em Contato",
+      "PROFILE_PLACEHOLDER": "Foto do Perfil"
+    },
+    "SKILLS": {
+      "TITLE": "Principais Tecnologias",
+      "FRONTEND": "Frontend",
+      "BACKEND": "Backend",
+      "MOBILE": "Mobile",
+      "DEVOPS": "DevOps",
+      "ML": "Machine Learning"
+    },
+    "FEATURED": {
+      "TITLE": "Projetos em Destaque",
+      "PROJECT1": {
+        "TITLE": "E-commerce Platform",
+        "DESC": "Plataforma completa de e-commerce com Angular e Node.js"
+      },
+      "PROJECT2": {
+        "TITLE": "Task Management App",
+        "DESC": "Aplicativo de gerenciamento de tarefas com real-time"
+      },
+      "PROJECT3": {
+        "TITLE": "Analytics Dashboard",
+        "DESC": "Dashboard de analytics com visualizações interativas"
+      },
+      "BTN_ALL": "Ver Todos os Projetos"
+    },
+    "CTA": {
+      "TITLE": "Vamos trabalhar juntos?",
+      "DESC": "Estou sempre aberto a novos desafios e oportunidades interessantes.",
+      "BTN_CONTACT": "Entre em Contato"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- install ngx-translate packages and wire I18n module
- add I18n service with dynamic LOCALE_ID provider
- translate layout and home page and provide English/Portuguese JSON files

## Testing
- `npm test` *(fails: Cannot find module '@ngx-translate/core')*

------
https://chatgpt.com/codex/tasks/task_e_68971f209ec48329bdc7c7c7fc0a2e4d