### PR TITLE
Add locale-aware routing with validation

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,33 +1,49 @@
 import { Routes } from '@angular/router';
+import { LocaleGuard } from './core/i18n/locale.guard';
 
 export const routes: Routes = [
   {
+    path: ':lang',
+    canActivate: [LocaleGuard],
+    children: [
+      {
+        path: '',
+        loadComponent: () => import('./pages/home/home').then(m => m.HomeComponent),
+        title: 'home.title'
+      },
+      {
+        path: 'about',
+        loadComponent: () => import('./pages/about/about').then(m => m.AboutComponent),
+        title: 'about.title'
+      },
+      {
+        path: 'projects',
+        loadComponent: () => import('./pages/projects/projects').then(m => m.ProjectsComponent),
+        title: 'projects.title'
+      },
+      {
+        path: 'resume',
+        loadComponent: () => import('./pages/resume/resume').then(m => m.ResumeComponent),
+        title: 'resume.title'
+      },
+      {
+        path: 'contact',
+        loadComponent: () => import('./pages/contact/contact').then(m => m.ContactComponent),
+        title: 'contact.title'
+      },
+      {
+        path: '**',
+        redirectTo: ''
+      }
+    ]
+  },
+  {
     path: '',
-    loadComponent: () => import('./pages/home/home').then(m => m.HomeComponent),
-    title: 'Home - Landing Page'
-  },
-  {
-    path: 'about',
-    loadComponent: () => import('./pages/about/about').then(m => m.AboutComponent),
-    title: 'Sobre - Landing Page'
-  },
-  {
-    path: 'projects',
-    loadComponent: () => import('./pages/projects/projects').then(m => m.ProjectsComponent),
-    title: 'Projetos - Landing Page'
-  },
-  {
-    path: 'resume',
-    loadComponent: () => import('./pages/resume/resume').then(m => m.ResumeComponent),
-    title: 'Currículo - Landing Page'
-  },
-  {
-    path: 'contact',
-    loadComponent: () => import('./pages/contact/contact').then(m => m.ContactComponent),
-    title: 'Contato - Landing Page'
+    pathMatch: 'full',
+    redirectTo: 'pt-br'
   },
   {
     path: '**',
-    redirectTo: ''
+    redirectTo: 'pt-br'
   }
 ];

--- a/src/app/core/i18n/locale.guard.ts
+++ b/src/app/core/i18n/locale.guard.ts
@@ -1,0 +1,16 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+const SUPPORTED_LANGS = ['en', 'pt-br'];
+
+export const LocaleGuard: CanActivateFn = (route) => {
+  const lang = route.paramMap.get('lang') ?? '';
+  const router = inject(Router);
+
+  if (SUPPORTED_LANGS.includes(lang)) {
+    return true;
+  }
+
+  return router.parseUrl('/pt-br');
+};
+

--- a/src/app/layout/navigation/navigation.html
+++ b/src/app/layout/navigation/navigation.html
@@ -2,10 +2,10 @@
   <ul class="nav-list">
     @for (item of navigationItems; track item.path) {
       <li class="nav-item">
-        <a 
-          [routerLink]="item.path" 
+        <a
+          [routerLink]="getPath(item.path)"
           routerLinkActive="active"
-          [routerLinkActiveOptions]="{exact: item.path === '/'}"
+          [routerLinkActiveOptions]="{exact: item.path === ''}"
           class="nav-link">
           {{ item.label }}
         </a>

--- a/src/app/layout/navigation/navigation.ts
+++ b/src/app/layout/navigation/navigation.ts
@@ -1,5 +1,5 @@
-import { Component } from '@angular/core';
-import { RouterLink, RouterLinkActive } from '@angular/router';
+import { Component, inject } from '@angular/core';
+import { Router, RouterLink, RouterLinkActive } from '@angular/router';
 
 @Component({
   selector: 'app-navigation',
@@ -8,11 +8,22 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
   styleUrl: './navigation.scss'
 })
 export class NavigationComponent {
+  private router = inject(Router);
+
   navigationItems = [
-    { path: '/', label: 'Home' },
-    { path: '/about', label: 'Sobre' },
-    { path: '/projects', label: 'Projetos' },
-    { path: '/resume', label: 'Currículo' },
-    { path: '/contact', label: 'Contato' }
+    { path: '', label: 'Home' },
+    { path: 'about', label: 'Sobre' },
+    { path: 'projects', label: 'Projetos' },
+    { path: 'resume', label: 'Currículo' },
+    { path: 'contact', label: 'Contato' }
   ];
+
+  get currentLang(): string {
+    const lang = this.router.url.split('/')[1];
+    return lang || 'pt-br';
+  }
+
+  getPath(path: string) {
+    return ['/', this.currentLang, path].filter(Boolean);
+  }
 }

--- a/src/app/pages/home/home.html
+++ b/src/app/pages/home/home.html
@@ -10,8 +10,8 @@
           Apaixonado por criar soluções inovadoras e escaláveis.
         </p>
         <div class="hero-actions">
-          <a routerLink="/projects" class="btn btn-primary">Ver Projetos</a>
-          <a routerLink="/contact" class="btn btn-secondary">Entre em Contato</a>
+          <a [routerLink]="getLink('projects')" class="btn btn-primary">Ver Projetos</a>
+          <a [routerLink]="getLink('contact')" class="btn btn-secondary">Entre em Contato</a>
         </div>
       </div>
       <div class="hero-image">
@@ -129,7 +129,7 @@
         </div>
       </div>
       <div class="projects-cta">
-        <a routerLink="/projects" class="btn btn-outline">Ver Todos os Projetos</a>
+        <a [routerLink]="getLink('projects')" class="btn btn-outline">Ver Todos os Projetos</a>
       </div>
     </div>
   </section>
@@ -140,7 +140,7 @@
       <div class="cta-content">
         <h2>Vamos trabalhar juntos?</h2>
         <p>Estou sempre aberto a novos desafios e oportunidades interessantes.</p>
-        <a routerLink="/contact" class="btn btn-primary">Entre em Contato</a>
+        <a [routerLink]="getLink('contact')" class="btn btn-primary">Entre em Contato</a>
       </div>
     </div>
   </section>

--- a/src/app/pages/home/home.ts
+++ b/src/app/pages/home/home.ts
@@ -1,5 +1,5 @@
-import { Component } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Component, inject } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-home',
@@ -8,5 +8,14 @@ import { RouterLink } from '@angular/router';
   styleUrl: './home.scss'
 })
 export class HomeComponent {
+  private router = inject(Router);
 
+  get currentLang(): string {
+    const lang = this.router.url.split('/')[1];
+    return lang || 'pt-br';
+  }
+
+  getLink(path: string) {
+    return ['/', this.currentLang, path].filter(Boolean);
+  }
 }


### PR DESCRIPTION
## Summary
- wrap app routes in `:lang` prefix and add default redirects
- add `LocaleGuard` to validate language codes and redirect to `pt-br`
- prefix navigation and home links with current language

## Testing
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68971f2225a48329a13c69a3df622464