### PR TITLE
feat: add language switcher component

### DIFF
--- a/src/app/i18n/i18n.service.ts
+++ b/src/app/i18n/i18n.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class I18nService {
+  private readonly _language$ = new BehaviorSubject<string>('pt-br');
+
+  get currentLang(): string {
+    return this._language$.value;
+  }
+
+  setLanguage(lang: string): void {
+    this._language$.next(lang);
+  }
+
+  languageChanges(): Observable<string> {
+    return this._language$.asObservable();
+  }
+}
+

--- a/src/app/layout/header/header.html
+++ b/src/app/layout/header/header.html
@@ -5,6 +5,7 @@
         <h1>Meu Portfólio</h1>
       </div>
       <app-navigation></app-navigation>
+      <app-language-switcher></app-language-switcher>
     </div>
   </div>
 </header>

--- a/src/app/layout/header/header.ts
+++ b/src/app/layout/header/header.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { NavigationComponent } from '../navigation/navigation';
+import { LanguageSwitcherComponent } from '../language-switcher/language-switcher';
 
 @Component({
   selector: 'app-header',
-  imports: [NavigationComponent],
+  imports: [NavigationComponent, LanguageSwitcherComponent],
   templateUrl: './header.html',
   styleUrl: './header.scss'
 })

--- a/src/app/layout/language-switcher/language-switcher.html
+++ b/src/app/layout/language-switcher/language-switcher.html
@@ -1,0 +1,4 @@
+<div class="language-switcher">
+  <button type="button" (click)="switchLanguage('pt-br')" [class.active]="currentLang === 'pt-br'">pt-br</button>
+  <button type="button" (click)="switchLanguage('en')" [class.active]="currentLang === 'en'">en</button>
+</div>

--- a/src/app/layout/language-switcher/language-switcher.scss
+++ b/src/app/layout/language-switcher/language-switcher.scss
@@ -1,0 +1,16 @@
+.language-switcher {
+  display: flex;
+  gap: 0.5rem;
+
+  button {
+    background: none;
+    border: 1px solid #ccc;
+    padding: 0.25rem 0.5rem;
+    cursor: pointer;
+
+    &.active {
+      border-color: #000;
+      font-weight: bold;
+    }
+  }
+}

--- a/src/app/layout/language-switcher/language-switcher.spec.ts
+++ b/src/app/layout/language-switcher/language-switcher.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { LanguageSwitcherComponent } from './language-switcher';
+import { I18nService } from '../../i18n/i18n.service';
+
+describe('LanguageSwitcherComponent', () => {
+  let component: LanguageSwitcherComponent;
+  let fixture: ComponentFixture<LanguageSwitcherComponent>;
+  let i18nService: I18nService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LanguageSwitcherComponent, RouterTestingModule]
+    }).compileComponents();
+
+    i18nService = TestBed.inject(I18nService);
+    fixture = TestBed.createComponent(LanguageSwitcherComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should update active language in I18nService when switching', () => {
+    component.switchLanguage('en');
+    expect(i18nService.currentLang).toBe('en');
+  });
+});

--- a/src/app/layout/language-switcher/language-switcher.ts
+++ b/src/app/layout/language-switcher/language-switcher.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { I18nService } from '../../i18n/i18n.service';
+
+@Component({
+  selector: 'app-language-switcher',
+  imports: [CommonModule],
+  templateUrl: './language-switcher.html',
+  styleUrl: './language-switcher.scss'
+})
+export class LanguageSwitcherComponent {
+  currentLang: string;
+
+  constructor(private i18nService: I18nService, private router: Router) {
+    this.currentLang = this.i18nService.currentLang;
+  }
+
+  switchLanguage(lang: string): void {
+    if (lang === this.i18nService.currentLang) {
+      return;
+    }
+    this.i18nService.setLanguage(lang);
+    const currentUrl = this.router.url;
+    const pathWithoutLang = currentUrl.replace(/^\/(en|pt-br)/, '');
+    this.router.navigateByUrl(`/${lang}${pathWithoutLang}`);
+    this.currentLang = lang;
+  }
+}


### PR DESCRIPTION
## Summary
- add i18n service and language switcher component
- integrate language switcher into header navigation
- test language change updates active language in service

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform. Please, set "CHROME_BIN" env variable.)*
- `npm run lint` *(fails: Cannot find "lint" target for the specified project.)*

------
https://chatgpt.com/codex/tasks/task_e_68971f246bc08329b09e0f3ce641c2a7