### PR TITLE
Switch locale references to pt-BR

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -40,10 +40,10 @@ export const routes: Routes = [
   {
     path: '',
     pathMatch: 'full',
-    redirectTo: 'pt-br'
+    redirectTo: 'pt-BR'
   },
   {
     path: '**',
-    redirectTo: 'pt-br'
+    redirectTo: 'pt-BR'
   }
 ];

--- a/src/app/core/i18n/locale.guard.ts
+++ b/src/app/core/i18n/locale.guard.ts
@@ -1,7 +1,7 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 
-const SUPPORTED_LANGS = ['en', 'pt-br'];
+const SUPPORTED_LANGS = ['en', 'pt-BR'];
 
 export const LocaleGuard: CanActivateFn = (route) => {
   const lang = route.paramMap.get('lang') ?? '';
@@ -11,6 +11,6 @@ export const LocaleGuard: CanActivateFn = (route) => {
     return true;
   }
 
-  return router.parseUrl('/pt-br');
+  return router.parseUrl('/pt-BR');
 };
 

--- a/src/app/i18n/i18n.service.ts
+++ b/src/app/i18n/i18n.service.ts
@@ -3,7 +3,7 @@ import { BehaviorSubject, Observable } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class I18nService {
-  private readonly _language$ = new BehaviorSubject<string>('pt-br');
+  private readonly _language$ = new BehaviorSubject<string>('pt-BR');
 
   get currentLang(): string {
     return this._language$.value;

--- a/src/app/layout/language-switcher/language-switcher.html
+++ b/src/app/layout/language-switcher/language-switcher.html
@@ -1,4 +1,4 @@
 <div class="language-switcher">
-  <button type="button" (click)="switchLanguage('pt-br')" [class.active]="currentLang === 'pt-br'">pt-br</button>
+  <button type="button" (click)="switchLanguage('pt-BR')" [class.active]="currentLang === 'pt-BR'">pt-BR</button>
   <button type="button" (click)="switchLanguage('en')" [class.active]="currentLang === 'en'">en</button>
 </div>

--- a/src/app/layout/language-switcher/language-switcher.ts
+++ b/src/app/layout/language-switcher/language-switcher.ts
@@ -10,7 +10,7 @@ import { I18nService } from '../../i18n/i18n.service';
   styleUrl: './language-switcher.scss'
 })
 export class LanguageSwitcherComponent {
-  currentLang: string;
+  currentLang: string = 'pt-BR';
 
   constructor(private i18nService: I18nService, private router: Router) {
     this.currentLang = this.i18nService.currentLang;
@@ -22,7 +22,7 @@ export class LanguageSwitcherComponent {
     }
     this.i18nService.setLanguage(lang);
     const currentUrl = this.router.url;
-    const pathWithoutLang = currentUrl.replace(/^\/(en|pt-br)/, '');
+    const pathWithoutLang = currentUrl.replace(/^\/(en|pt-BR)/, '');
     this.router.navigateByUrl(`/${lang}${pathWithoutLang}`);
     this.currentLang = lang;
   }

--- a/src/app/layout/navigation/navigation.ts
+++ b/src/app/layout/navigation/navigation.ts
@@ -21,7 +21,7 @@ export class NavigationComponent {
 
   get currentLang(): string {
     const lang = this.router.url.split('/')[1];
-    return lang || 'pt-br';
+    return lang || 'pt-BR';
   }
 
   getPath(path: string) {

--- a/src/app/pages/home/home.ts
+++ b/src/app/pages/home/home.ts
@@ -13,7 +13,7 @@ export class HomeComponent {
 
   get currentLang(): string {
     const lang = this.router.url.split('/')[1];
-    return lang || 'pt-br';
+    return lang || 'pt-BR';
   }
 
   getLink(path: string) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,7 @@ const browserDistFolder = join(import.meta.dirname, '../browser');
 const app = express();
 const angularApp = new AngularNodeAppEngine();
 
-const supportedLangs = ['en', 'pt-br'];
+const supportedLangs = ['en', 'pt-BR'];
 
 app.use('/:lang', (req, res, next) => {
   const { lang } = req.params as { lang: string };
@@ -21,7 +21,7 @@ app.use('/:lang', (req, res, next) => {
     res.locals['lang'] = lang;
     req.url = req.originalUrl.replace(/^\/[^/]+/, '');
   } else {
-    res.locals['lang'] = 'pt-br';
+    res.locals['lang'] = 'pt-BR';
     req.url = req.originalUrl;
   }
   next();
@@ -29,7 +29,7 @@ app.use('/:lang', (req, res, next) => {
 
 app.use((req, res, next) => {
   if (!res.locals['lang']) {
-    res.locals['lang'] = 'pt-br';
+    res.locals['lang'] = 'pt-BR';
   }
   next();
 });


### PR DESCRIPTION
## Summary
- update locale guard and route defaults to use `pt-BR`
- adjust language switcher and navigation to recognize `pt-BR`
- set default language value to `pt-BR`

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_689e3cdd06688329be18651d68e19c56