### PR TITLE
refactor: rename styleUrl to styleUrls

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -7,7 +7,7 @@ import { FooterComponent } from './layout/footer/footer';
   selector: 'app-root',
   imports: [RouterOutlet, HeaderComponent, FooterComponent],
   templateUrl: './app.html',
-  styleUrl: './app.scss'
+  styleUrls: ['./app.scss']
 })
 export class App {
   protected readonly title = signal('Landing Page Pessoal');

--- a/src/app/layout/footer/footer.ts
+++ b/src/app/layout/footer/footer.ts
@@ -5,7 +5,7 @@ import { TranslateModule } from '@ngx-translate/core';
   selector: 'app-footer',
   imports: [TranslateModule],
   templateUrl: './footer.html',
-  styleUrl: './footer.scss'
+  styleUrls: ['./footer.scss']
 })
 export class FooterComponent {
 

--- a/src/app/layout/header/header.ts
+++ b/src/app/layout/header/header.ts
@@ -7,7 +7,7 @@ import { LanguageSwitcherComponent } from '../language-switcher/language-switche
   selector: 'app-header',
   imports: [NavigationComponent, TranslateModule, LanguageSwitcherComponent],
   templateUrl: './header.html',
-  styleUrl: './header.scss'
+  styleUrls: ['./header.scss']
 })
 export class HeaderComponent {
 

--- a/src/app/layout/language-switcher/language-switcher.ts
+++ b/src/app/layout/language-switcher/language-switcher.ts
@@ -7,7 +7,7 @@ import { I18nService } from '../../i18n/i18n.service';
   selector: 'app-language-switcher',
   imports: [CommonModule],
   templateUrl: './language-switcher.html',
-  styleUrl: './language-switcher.scss'
+  styleUrls: ['./language-switcher.scss']
 })
 export class LanguageSwitcherComponent {
   currentLang: string;

--- a/src/app/layout/navigation/navigation.ts
+++ b/src/app/layout/navigation/navigation.ts
@@ -6,7 +6,7 @@ import { TranslateModule } from '@ngx-translate/core';
   selector: 'app-navigation',
   imports: [RouterLink, RouterLinkActive, TranslateModule],
   templateUrl: './navigation.html',
-  styleUrl: './navigation.scss'
+  styleUrls: ['./navigation.scss']
 })
 export class NavigationComponent {
   private router = inject(Router);

--- a/src/app/pages/about/about.ts
+++ b/src/app/pages/about/about.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
   selector: 'app-about',
   imports: [],
   templateUrl: './about.html',
-  styleUrl: './about.scss'
+  styleUrls: ['./about.scss']
 })
 export class AboutComponent {
 

--- a/src/app/pages/contact/contact.ts
+++ b/src/app/pages/contact/contact.ts
@@ -14,7 +14,7 @@ interface ContactForm {
   selector: 'app-contact',
   imports: [FormsModule, CommonModule],
   templateUrl: './contact.html',
-  styleUrl: './contact.scss'
+  styleUrls: ['./contact.scss']
 })
 export class ContactComponent {
   formData: ContactForm = {

--- a/src/app/pages/home/home.ts
+++ b/src/app/pages/home/home.ts
@@ -6,7 +6,7 @@ import { TranslateModule } from '@ngx-translate/core';
   selector: 'app-home',
   imports: [RouterLink, TranslateModule],
   templateUrl: './home.html',
-  styleUrl: './home.scss'
+  styleUrls: ['./home.scss']
 })
 export class HomeComponent {
   private router = inject(Router);

--- a/src/app/pages/projects/projects.ts
+++ b/src/app/pages/projects/projects.ts
@@ -18,7 +18,7 @@ interface Project {
   selector: 'app-projects',
   imports: [CommonModule],
   templateUrl: './projects.html',
-  styleUrl: './projects.scss'
+  styleUrls: ['./projects.scss']
 })
 export class ProjectsComponent implements OnInit {
   projects: Project[] = [

--- a/src/app/pages/resume/resume.ts
+++ b/src/app/pages/resume/resume.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
   selector: 'app-resume',
   imports: [],
   templateUrl: './resume.html',
-  styleUrl: './resume.scss'
+  styleUrls: ['./resume.scss']
 })
 export class ResumeComponent {
 


### PR DESCRIPTION
## Summary
- use `styleUrls` arrays in all components instead of `styleUrl`

## Testing
- `npx tsc -p tsconfig.app.json --noEmit`
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `npm run build` *(fails: An error occurred while extracting routes)*

------
https://chatgpt.com/codex/tasks/task_e_689e3cd9b8bc83298ab208cf193251ba