### PR TITLE
refactor: use reactive project filters

### DIFF
--- a/src/app/pages/projects/projects.html
+++ b/src/app/pages/projects/projects.html
@@ -14,10 +14,10 @@
   <section class="projects-filter">
     <div class="container">
       <div class="filter-tabs">
-        <button class="filter-btn active" (click)="filterProjects('all')">Todos</button>
-        <button class="filter-btn" (click)="filterProjects('frontend')">Frontend</button>
-        <button class="filter-btn" (click)="filterProjects('fullstack')">Full Stack</button>
-        <button class="filter-btn" (click)="filterProjects('mobile')">Mobile</button>
+        <button class="filter-btn" [class.active]="currentFilter === 'all'" (click)="filterProjects('all')">Todos</button>
+        <button class="filter-btn" [class.active]="currentFilter === 'frontend'" (click)="filterProjects('frontend')">Frontend</button>
+        <button class="filter-btn" [class.active]="currentFilter === 'fullstack'" (click)="filterProjects('fullstack')">Full Stack</button>
+        <button class="filter-btn" [class.active]="currentFilter === 'mobile'" (click)="filterProjects('mobile')">Mobile</button>
       </div>
     </div>
   </section>

--- a/src/app/pages/projects/projects.ts
+++ b/src/app/pages/projects/projects.ts
@@ -105,15 +105,10 @@ export class ProjectsComponent implements OnInit {
 
   filterProjects(category: string) {
     this.currentFilter = category;
-    
-    if (category === 'all') {
-      this.filteredProjects = this.projects;
-    } else {
-      this.filteredProjects = this.projects.filter(project => project.category === category);
-    }
 
-    // Update active filter button
-    document.querySelectorAll('.filter-btn').forEach(btn => btn.classList.remove('active'));
-    document.querySelector(`[onclick="filterProjects('${category}')"]`)?.classList.add('active');
+    this.filteredProjects =
+      category === 'all'
+        ? this.projects
+        : this.projects.filter(project => project.category === category);
   }
 }


### PR DESCRIPTION
## Summary
- remove DOM queries in project filtering logic
- bind filter buttons' active state to currentFilter

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_689e3ced29cc8329a188cc4ca5de2204