### PR TITLE
feat: mark components as standalone

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -5,6 +5,7 @@ import { FooterComponent } from './layout/footer/footer';
 
 @Component({
   selector: 'app-root',
+  standalone: true,
   imports: [RouterOutlet, HeaderComponent, FooterComponent],
   templateUrl: './app.html',
   styleUrl: './app.scss'

--- a/src/app/layout/footer/footer.ts
+++ b/src/app/layout/footer/footer.ts
@@ -3,6 +3,7 @@ import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-footer',
+  standalone: true,
   imports: [TranslateModule],
   templateUrl: './footer.html',
   styleUrl: './footer.scss'

--- a/src/app/layout/header/header.ts
+++ b/src/app/layout/header/header.ts
@@ -5,6 +5,7 @@ import { LanguageSwitcherComponent } from '../language-switcher/language-switche
 
 @Component({
   selector: 'app-header',
+  standalone: true,
   imports: [NavigationComponent, TranslateModule, LanguageSwitcherComponent],
   templateUrl: './header.html',
   styleUrl: './header.scss'

--- a/src/app/layout/language-switcher/language-switcher.ts
+++ b/src/app/layout/language-switcher/language-switcher.ts
@@ -5,6 +5,7 @@ import { I18nService } from '../../i18n/i18n.service';
 
 @Component({
   selector: 'app-language-switcher',
+  standalone: true,
   imports: [CommonModule],
   templateUrl: './language-switcher.html',
   styleUrl: './language-switcher.scss'

--- a/src/app/layout/navigation/navigation.ts
+++ b/src/app/layout/navigation/navigation.ts
@@ -4,6 +4,7 @@ import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-navigation',
+  standalone: true,
   imports: [RouterLink, RouterLinkActive, TranslateModule],
   templateUrl: './navigation.html',
   styleUrl: './navigation.scss'

--- a/src/app/pages/about/about.ts
+++ b/src/app/pages/about/about.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-about',
+  standalone: true,
   imports: [],
   templateUrl: './about.html',
   styleUrl: './about.scss'

--- a/src/app/pages/contact/contact.ts
+++ b/src/app/pages/contact/contact.ts
@@ -12,6 +12,7 @@ interface ContactForm {
 
 @Component({
   selector: 'app-contact',
+  standalone: true,
   imports: [FormsModule, CommonModule],
   templateUrl: './contact.html',
   styleUrl: './contact.scss'

--- a/src/app/pages/home/home.ts
+++ b/src/app/pages/home/home.ts
@@ -4,6 +4,7 @@ import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-home',
+  standalone: true,
   imports: [RouterLink, TranslateModule],
   templateUrl: './home.html',
   styleUrl: './home.scss'

--- a/src/app/pages/projects/projects.ts
+++ b/src/app/pages/projects/projects.ts
@@ -16,6 +16,7 @@ interface Project {
 
 @Component({
   selector: 'app-projects',
+  standalone: true,
   imports: [CommonModule],
   templateUrl: './projects.html',
   styleUrl: './projects.scss'

--- a/src/app/pages/resume/resume.ts
+++ b/src/app/pages/resume/resume.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-resume',
+  standalone: true,
   imports: [],
   templateUrl: './resume.html',
   styleUrl: './resume.scss'


### PR DESCRIPTION
## Summary
- mark app and layout components as standalone Angular components
- mark page components as standalone for Angular standalone APIs

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `npm run lint` *(fails: Cannot find "lint" target)*

------
https://chatgpt.com/codex/tasks/task_e_689e3cd2b1a083298ea51e5e9ecf4f31